### PR TITLE
Add tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+erlang 23.3.4
+elixir 1.12.2-otp-23
+nodejs 14.17.3


### PR DESCRIPTION
Add LTS nodejs, Latest elixir with OTP 23 and erlang 23. 

Erlang 24 is also available but need custom env for installation. [issue](https://github.com/erlang/otp/issues/4821#issuecomment-874980512)