### PR TITLE
Create queues system

### DIFF
--- a/api/.credo.exs
+++ b/api/.credo.exs
@@ -1,0 +1,183 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: [
+          "lib/",
+          "test/",
+        ],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/", ~r"/lib/mix/tasks/"]
+      },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        #
+        ## Consistency Checks
+        #
+        {Credo.Check.Consistency.ExceptionNames, []},
+        {Credo.Check.Consistency.LineEndings, []},
+        {Credo.Check.Consistency.ParameterPatternMatching, []},
+        {Credo.Check.Consistency.SpaceAroundOperators, []},
+        {Credo.Check.Consistency.SpaceInParentheses, []},
+        {Credo.Check.Consistency.TabsOrSpaces, []},
+
+        #
+        ## Design Checks
+        #
+        # You can customize the priority of any check
+        # Priority values are: `low, normal, high, higher`
+        #
+        {Credo.Check.Design.AliasUsage,
+         [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        #
+        {Credo.Check.Design.TagTODO, [exit_status: 2]},
+        {Credo.Check.Design.TagFIXME, []},
+
+        #
+        ## Readability Checks
+        #
+        {Credo.Check.Readability.AliasOrder, []},
+        {Credo.Check.Readability.FunctionNames, []},
+        {Credo.Check.Readability.LargeNumbers, []},
+        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+        {Credo.Check.Readability.ModuleAttributeNames, []},
+        {Credo.Check.Readability.ModuleDoc, false},
+        {Credo.Check.Readability.ModuleNames, []},
+        {Credo.Check.Readability.ParenthesesInCondition, []},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+        {Credo.Check.Readability.PredicateFunctionNames, []},
+        {Credo.Check.Readability.PreferImplicitTry, []},
+        {Credo.Check.Readability.RedundantBlankLines, []},
+        {Credo.Check.Readability.Semicolons, []},
+        {Credo.Check.Readability.SpaceAfterCommas, []},
+        {Credo.Check.Readability.StringSigils, []},
+        {Credo.Check.Readability.TrailingBlankLine, []},
+        {Credo.Check.Readability.TrailingWhiteSpace, []},
+        {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+        {Credo.Check.Readability.VariableNames, []},
+
+        #
+        ## Refactoring Opportunities
+        #
+        {Credo.Check.Refactor.CondStatements, []},
+        {Credo.Check.Refactor.CyclomaticComplexity, []},
+        {Credo.Check.Refactor.FunctionArity, []},
+        {Credo.Check.Refactor.LongQuoteBlocks, []},
+        # {Credo.Check.Refactor.MapInto, []},
+        {Credo.Check.Refactor.MatchInCondition, []},
+        {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+        {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+        {Credo.Check.Refactor.Nesting, []},
+        {Credo.Check.Refactor.UnlessWithElse, []},
+        {Credo.Check.Refactor.WithClauses, []},
+
+        #
+        ## Warnings
+        #
+        {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+        {Credo.Check.Warning.BoolOperationOnSameValues, []},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+        {Credo.Check.Warning.IExPry, []},
+        {Credo.Check.Warning.IoInspect, []},
+        # {Credo.Check.Warning.LazyLogging, []},
+        {Credo.Check.Warning.MixEnv, false},
+        {Credo.Check.Warning.OperationOnSameValues, []},
+        {Credo.Check.Warning.OperationWithConstantResult, []},
+        {Credo.Check.Warning.RaiseInsideRescue, []},
+        {Credo.Check.Warning.UnusedEnumOperation, []},
+        {Credo.Check.Warning.UnusedFileOperation, []},
+        {Credo.Check.Warning.UnusedKeywordOperation, []},
+        {Credo.Check.Warning.UnusedListOperation, []},
+        {Credo.Check.Warning.UnusedPathOperation, []},
+        {Credo.Check.Warning.UnusedRegexOperation, []},
+        {Credo.Check.Warning.UnusedStringOperation, []},
+        {Credo.Check.Warning.UnusedTupleOperation, []},
+        {Credo.Check.Warning.UnsafeExec, []},
+
+        #
+        # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+
+        #
+        # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
+        #
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+        {Credo.Check.Consistency.UnusedVariableNames, false},
+        {Credo.Check.Design.DuplicatedCode, false},
+        {Credo.Check.Readability.AliasAs, false},
+        {Credo.Check.Readability.BlockPipe, false},
+        {Credo.Check.Readability.ImplTrue, false},
+        {Credo.Check.Readability.MultiAlias, false},
+        {Credo.Check.Readability.SeparateAliasRequire, false},
+        {Credo.Check.Readability.SinglePipe, false},
+        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Readability.StrictModuleLayout, false},
+        {Credo.Check.Readability.WithCustomTaggedTuple, false},
+        {Credo.Check.Refactor.ABCSize, false},
+        {Credo.Check.Refactor.AppendSingleItem, false},
+        {Credo.Check.Refactor.DoubleBooleanNegation, false},
+        {Credo.Check.Refactor.ModuleDependencies, false},
+        {Credo.Check.Refactor.NegatedIsNil, false},
+        {Credo.Check.Refactor.PipeChainStart, false},
+        {Credo.Check.Refactor.VariableRebinding, false},
+        {Credo.Check.Warning.LeakyEnvironment, false},
+        {Credo.Check.Warning.MapGetUnsafePass, false},
+        {Credo.Check.Warning.UnsafeToAtom, false}
+
+        #
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/api/lib/mix/tasks/generate_queues.ex
+++ b/api/lib/mix/tasks/generate_queues.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.OpenVac.GenerateQueues do
+  use Mix.Task
+
+  alias OpenVac.Repo
+  alias OpenVac.Queues.Queue
+
+  @doc """
+  Generates 20 millions row of queues for proof of concept and testing purpose
+  """
+  @requirements ["app.start"]
+  def run([]) do
+    1..1_000
+    |> Task.async_stream(
+      fn _ -> insert() end,
+      max_concurrency: 10
+    )
+    |> Enum.to_list()
+  end
+
+  defp insert() do
+    queues =
+      1..20_000
+      |> Enum.map(fn _ ->
+        %{
+          inserted_at: NaiveDateTime.local_now(),
+          updated_at: NaiveDateTime.local_now()
+        }
+      end)
+
+    Repo.insert_all(Queue, queues)
+  end
+end

--- a/api/lib/mix/tasks/get_queue.ex
+++ b/api/lib/mix/tasks/get_queue.ex
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.OpenVac.GetQueue do
+  use Mix.Task
+
+  alias OpenVac.Queues
+
+  @doc """
+  A simple comand to simulate retriving 100,000 queues with 100 concurrents
+  """
+  @requirements ["app.start"]
+  def run([]) do
+    result =
+      1..100_000
+      |> Task.async_stream(
+        fn _ -> Queues.get() end,
+        max_concurrency: 100
+      )
+      |> Enum.to_list()
+
+    IO.inspect("total: ")
+    IO.inspect(Enum.count(result))
+
+    IO.inspect("total unique: ")
+
+    result
+    |> Enum.map(fn {:ok, record} -> record.id end)
+    |> Enum.uniq()
+    |> Enum.count()
+    |> IO.inspect()
+  end
+end

--- a/api/lib/openvac/queues.ex
+++ b/api/lib/openvac/queues.ex
@@ -1,0 +1,38 @@
+defmodule OpenVac.Queues do
+  import Ecto.Query
+
+  alias OpenVac.Repo
+  alias OpenVac.Queues.Queue
+
+  @doc """
+  Retrieves and locks queue from database.
+
+  Returns a reserving record
+  """
+  def get() do
+    query =
+      Queue
+      |> select([:id])
+      |> where([q], is_nil(q.expired_at) or q.expired_at < ^now())
+      |> limit(1)
+      |> lock("for update skip locked")
+
+    update =
+      Queue
+      |> where([q], q.id in subquery(query))
+      |> select([:id, :token])
+
+    Repo.update_all(
+      update,
+      set: [token: generate_token(), expired_at: expired_at()]
+    )
+    |> case do
+      {1, [record]} -> record
+      err -> err
+    end
+  end
+
+  defp generate_token(), do: "a-random-token"
+  defp now(), do: DateTime.utc_now() |> DateTime.truncate(:second)
+  defp expired_at(), do: DateTime.add(now(), 10 * 60, :second)
+end

--- a/api/lib/openvac/queues/queue.ex
+++ b/api/lib/openvac/queues/queue.ex
@@ -1,0 +1,20 @@
+defmodule OpenVac.Queues.Queue do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "queues" do
+    field :expired_at, :utc_datetime
+    field :profile_id, :integer
+    field :paid_at, :utc_datetime
+    field :token, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(queue, attrs) do
+    queue
+    |> cast(attrs, [:token, :expired_at, :profile_id, :paid_at])
+    |> validate_required([:token])
+  end
+end

--- a/api/priv/repo/migrations/20210718144722_create_queues.exs
+++ b/api/priv/repo/migrations/20210718144722_create_queues.exs
@@ -1,0 +1,19 @@
+defmodule Openvac.Repo.Migrations.CreateQueues do
+  use Ecto.Migration
+
+  def change do
+    create table(:queues) do
+      add :token, :string
+      add :expired_at, :utc_datetime
+      add :paid_at, :utc_datetime
+      add :profile_id, :integer
+
+      timestamps()
+    end
+
+    # This index is with assumption that we'll query a queue which is not paid
+    # and expired.
+    index("queues", [:paid_at, :expired_at])
+    index("queues", [:token])
+  end
+end


### PR DESCRIPTION
Queues table required to be carefully design and index, Since, it would be most spike when the registration started

Currently, we would prefill table with available stock. For
instances, 20 million items. and when user want to reserve we could do a
single row lock
```sql
UPDATE queues
    SET token = <new random token>, expired_at = <new expired date>
    WHERE id = (
            SELECT q.id FROM queues q
            WHERE <not paid> and <expired>
            FOR UPDATE SKIP LOCKED
         )
```

With this approach, we don't need to worry phantom data and only lock
the row that we really need to.

To test data please try to run 

```
mix open_vac.generate_queues
mix open_vac.get_queue
```